### PR TITLE
[DNM] Bump wins version to v0.1.0

### DIFF
--- a/package/windows/Dockerfile
+++ b/package/windows/Dockerfile
@@ -6,7 +6,7 @@ ENV WMI_EXPORTER_ARCHIVER_VERSION 0.12.0
 
 SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-RUN $WINS_URL = 'https://github.com/rancher/wins/releases/download/v0.0.4/wins.exe'; \
+RUN $WINS_URL = 'https://github.com/rancher/wins/releases/download/v0.1.0/wins.exe'; \
     $DST_PATH = 'c:\wins.exe'; \
     \
     Write-Host ('Downloading Wins from {0} ...' -f $URL); \

--- a/package/windows/Dockerfile.20H2
+++ b/package/windows/Dockerfile.20H2
@@ -6,7 +6,7 @@ ENV WMI_EXPORTER_ARCHIVER_VERSION 0.12.0
 
 SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-RUN $WINS_URL = 'https://github.com/rancher/wins/releases/download/v0.0.4/wins.exe'; \
+RUN $WINS_URL = 'https://github.com/rancher/wins/releases/download/v0.1.0/wins.exe'; \
     $DST_PATH = 'c:\wins.exe'; \
     \
     Write-Host ('Downloading Wins from {0} ...' -f $URL); \


### PR DESCRIPTION
Blocked on release v0.1.0 of wins after merging https://github.com/rancher/wins/pull/14 and https://github.com/rancher/wins/pull/19

Related Issue: https://github.com/rancher/rancher/issues/31148