### PR TITLE
Bump windows_exporter.exe to 0.16.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -62,68 +62,6 @@ trigger:
 
 ---
 kind: pipeline
-name: windows-1903
-
-platform:
-  os: windows
-  arch: amd64
-  version: 1903
-
-steps:
-- name: docker-publish
-  image: plugins/docker
-  settings:
-    build_args:
-    - SERVERCORE_VERSION=1903
-    - ARCH=amd64
-    - VERSION=${DRONE_TAG}
-    context: package/windows
-    custom_dns: 1.1.1.1
-    dockerfile: package/windows/Dockerfile
-    password:
-      from_secret: docker_password
-    repo: rancher/windows_exporter-package
-    tag: ${DRONE_TAG}-windows-1903
-    username:
-      from_secret: docker_username
-  volumes:
-  - name: docker_pipe
-    path: \\\\.\\pipe\\docker_engine
-  when:
-    event:
-    - tag
-    ref:
-    - refs/heads/master
-    - refs/tags/*
-
-- name: slack_notify
-  image: plugins/slack
-  settings:
-    template: "Build {{build.link}} failed to publish an image/artifact.\n"
-    username: Drone_Publish
-    webhook:
-      from_secret: slack_webhook
-  when:
-    event:
-      exclude:
-      - pull_request
-    instance:
-    - drone-publish.rancher.io
-    status:
-    - failure
-
-volumes:
-- name: docker_pipe
-  host:
-    path: \\\\.\\pipe\\docker_engine
-
-trigger:
-  event:
-    exclude:
-    - promote
-
----
-kind: pipeline
 name: windows-2004
 
 platform:
@@ -299,6 +237,5 @@ trigger:
 
 depends_on:
 - windows-1809
-- windows-1903
 - windows-2004
 - windows-20H2

--- a/.drone.yml
+++ b/.drone.yml
@@ -124,67 +124,6 @@ trigger:
 
 ---
 kind: pipeline
-name: windows-1909
-
-platform:
-  os: windows
-  arch: amd64
-  version: 1909
-
-steps:
-- name: docker-publish
-  image: plugins/docker
-  settings:
-    build_args:
-    - SERVERCORE_VERSION=1909
-    - ARCH=amd64
-    - VERSION=${DRONE_TAG}
-    context: package/windows
-    custom_dns: 1.1.1.1
-    dockerfile: package/windows/Dockerfile
-    username:
-      from_secret: docker_username
-    password:
-      from_secret: docker_password
-    repo: rancher/windows_exporter-package
-    tag: ${DRONE_TAG}-windows-1909
-  volumes:
-  - name: docker_pipe
-    path: \\\\.\\pipe\\docker_engine
-  when:
-    event:
-    - tag
-    ref:
-    - refs/heads/master
-    - refs/tags/*
-
-- name: slack_notify
-  image: plugins/slack
-  settings:
-    template: "Build {{build.link}} failed to publish an image/artifact.\n"
-    username: Drone_Publish
-    webhook:
-      from_secret: slack_webhook
-  when:
-    event:
-      exclude:
-      - pull_request
-    instance:
-    - drone-publish.rancher.io
-    status:
-    - failure
-
-volumes:
-- name: docker_pipe
-  host:
-    path: \\\\.\\pipe\\docker_engine
-
-trigger:
-  event:
-    exclude:
-    - promote
----
-kind: pipeline
 name: windows-2004
 
 platform:
@@ -361,6 +300,5 @@ trigger:
 depends_on:
 - windows-1809
 - windows-1903
-- windows-1909
 - windows-2004
 - windows-20H2

--- a/manifest.tmpl
+++ b/manifest.tmpl
@@ -13,12 +13,6 @@ manifests:
       os: windows
       version: 1903
   -
-    image: rancher/windows_exporter-package:{{build.tag}}-windows-1909
-    platform:
-      architecture: amd64
-      os: windows
-      version: 1909
-  -
     image: rancher/windows_exporter-package:{{build.tag}}-windows-2004
     platform:
       architecture: amd64

--- a/manifest.tmpl
+++ b/manifest.tmpl
@@ -7,12 +7,6 @@ manifests:
       os: windows
       version: 1809
   -
-    image: rancher/windows_exporter-package:{{build.tag}}-windows-1903
-    platform:
-      architecture: amd64
-      os: windows
-      version: 1903
-  -
     image: rancher/windows_exporter-package:{{build.tag}}-windows-2004
     platform:
       architecture: amd64

--- a/package/windows/Dockerfile
+++ b/package/windows/Dockerfile
@@ -2,7 +2,7 @@ ARG SERVERCORE_VERSION
 
 FROM mcr.microsoft.com/windows/servercore:${SERVERCORE_VERSION} as download
 ENV ARCH=amd64
-ENV WINDOWS_EXPORTER_ARCHIVER_VERSION 0.15.0
+ENV WINDOWS_EXPORTER_ARCHIVER_VERSION 0.16.0
 
 SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/package/windows/Dockerfile.20H2
+++ b/package/windows/Dockerfile.20H2
@@ -2,7 +2,7 @@ ARG SERVERCORE_VERSION
 
 FROM mcr.microsoft.com/windows/servercore:${SERVERCORE_VERSION} as download
 ENV ARCH=amd64
-ENV WINDOWS_EXPORTER_ARCHIVER_VERSION 0.15.0
+ENV WINDOWS_EXPORTER_ARCHIVER_VERSION 0.16.0
 
 SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 


### PR DESCRIPTION
Should be done as part of https://github.com/rancher/rancher/issues/32519 to rebase to the latest upstreams.

Pending changes to rancher-windows-exporter to account for breaking changes in https://github.com/prometheus-community/windows_exporter/releases, if necessary.