### PR TITLE
Adding Windows Server 2022 and removing 2004.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,6 @@
 ---
 kind: pipeline
+type: docker
 name: windows-1809
 
 platform:
@@ -8,6 +9,29 @@ platform:
   version: 1809
 
 steps:
+- name: docker-build
+  image: plugins/docker
+  settings:
+    dry_run: true
+    build_args:
+    - SERVERCORE_VERSION=1809
+    - ARCH=amd64
+    - VERSION=${DRONE_TAG}
+    context: package/windows
+    custom_dns: 1.1.1.1
+    dockerfile: package/windows/Dockerfile
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+    repo: rancher/windows_exporter-package
+    tag: ${DRONE_COMMIT/+/-}-windows-1809
+  volumes:
+  - name: docker_pipe
+    path: \\\\.\\pipe\\docker_engine
+  when:
+    event:
+    - pull_request
 - name: docker-publish
   image: plugins/docker
   settings:
@@ -62,73 +86,7 @@ trigger:
 
 ---
 kind: pipeline
-name: windows-2004
-
-platform:
-  os: windows
-  arch: amd64
-  version: 2004
-
-# remove this and use upstream images when https://github.com/drone/drone-git/pull/25 is merged
-clone:
-  disable: true
-
-steps:
-  - name: clone
-    image: luthermonson/drone-git:windows-2004-amd64
-  - name: docker-publish
-    image: luthermonson/drone-docker:2004
-    settings:
-      build_args:
-        - SERVERCORE_VERSION=2004
-        - ARCH=amd64
-        - VERSION=${DRONE_TAG}
-      context: package/windows
-      custom_dns: 1.1.1.1
-      dockerfile: package/windows/Dockerfile
-      username:
-        from_secret: docker_username
-      password:
-        from_secret: docker_password
-      repo: rancher/windows_exporter-package
-      tag: ${DRONE_TAG}-windows-2004
-    volumes:
-      - name: docker_pipe
-        path: \\\\.\\pipe\\docker_engine
-    when:
-      event:
-        - tag
-      ref:
-        - refs/heads/master
-        - refs/tags/*
-  - name: slack_notify
-    image: plugins/slack
-    settings:
-      template: "Build {{build.link}} failed to publish an image/artifact.\n"
-      username: Drone_Publish
-      webhook:
-        from_secret: slack_webhook
-    when:
-      event:
-        exclude:
-          - pull_request
-      instance:
-        - drone-publish.rancher.io
-      status:
-        - failure
-
-volumes:
-  - name: docker_pipe
-    host:
-      path: \\\\.\\pipe\\docker_engine
-
-trigger:
-  event:
-    exclude:
-      - promote
-
----
-kind: pipeline
+type: docker
 name: windows-20H2
 
 platform:
@@ -142,9 +100,32 @@ clone:
 
 steps:
   - name: clone
-    image: luthermonson/drone-git:windows-20H2-amd64
+    image: rancher/drone-images:git-20H2
+  - name: docker-build
+    image: rancher/drone-images:docker-20H2
+    settings:
+      dry_run: true
+      build_args:
+        - SERVERCORE_VERSION=20H2
+        - ARCH=amd64
+        - VERSION=${DRONE_TAG}
+      context: package/windows
+      custom_dns: 1.1.1.1
+      dockerfile: package/windows/Dockerfile.20H2
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      repo: rancher/windows_exporter-package
+      tag: ${DRONE_COMMIT/+/-}-windows-20H2
+    volumes:
+      - name: docker_pipe
+        path: \\\\.\\pipe\\docker_engine
+    when:
+      event:
+        - pull_request
   - name: docker-publish
-    image: luthermonson/drone-docker:20H2
+    image: rancher/drone-images:docker-20H2
     settings:
       build_args:
         - SERVERCORE_VERSION=20H2
@@ -193,8 +174,101 @@ trigger:
   event:
     exclude:
       - promote
+
 ---
 kind: pipeline
+type: docker
+name: windows-2022
+
+platform:
+  os: windows
+  arch: amd64
+  version: 2022
+
+# remove this and use upstream images when https://github.com/drone/drone-git/pull/25 is merged
+clone:
+  disable: true
+
+steps:
+  - name: clone
+    image: rancher/drone-images:git-amd64-ltsc2022
+  - name: docker-build
+    image: rancher/drone-images:docker-amd64-ltsc2022
+    settings:
+      dry_run: true
+      build_args:
+        - SERVERCORE_VERSION=ltsc2022
+        - ARCH=amd64
+        - VERSION=${DRONE_TAG}
+      context: package/windows
+      custom_dns: 1.1.1.1
+      dockerfile: package/windows/Dockerfile
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      repo: rancher/windows_exporter-package
+      tag: ${DRONE_COMMIT/+/-}-windows-ltsc2022
+    volumes:
+      - name: docker_pipe
+        path: \\\\.\\pipe\\docker_engine
+    when:
+      event:
+        - pull_request
+  - name: docker-publish
+    image: rancher/drone-images:docker-amd64-ltsc2022
+    settings:
+      build_args:
+        - SERVERCORE_VERSION=ltsc2022
+        - ARCH=amd64
+        - VERSION=${DRONE_TAG}
+      context: package/windows
+      custom_dns: 1.1.1.1
+      dockerfile: package/windows/Dockerfile
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      repo: rancher/windows_exporter-package
+      tag: ${DRONE_TAG}-windows-ltsc2022
+    volumes:
+      - name: docker_pipe
+        path: \\\\.\\pipe\\docker_engine
+    when:
+      event:
+        - tag
+      ref:
+        - refs/heads/master
+        - refs/tags/*
+  - name: slack_notify
+    image: plugins/slack
+    settings:
+      template: "Build {{build.link}} failed to publish an image/artifact.\n"
+      username: Drone_Publish
+      webhook:
+        from_secret: slack_webhook
+    when:
+      event:
+        exclude:
+          - pull_request
+      instance:
+        - drone-publish.rancher.io
+      status:
+        - failure
+
+volumes:
+  - name: docker_pipe
+    host:
+      path: \\\\.\\pipe\\docker_engine
+
+trigger:
+  event:
+    exclude:
+      - promote
+
+---
+kind: pipeline
+type: docker
 name: manifest
 
 platform:
@@ -237,5 +311,5 @@ trigger:
 
 depends_on:
 - windows-1809
-- windows-2004
 - windows-20H2
+- windows-2022

--- a/manifest.tmpl
+++ b/manifest.tmpl
@@ -7,14 +7,14 @@ manifests:
       os: windows
       version: 1809
   -
-    image: rancher/windows_exporter-package:{{build.tag}}-windows-2004
-    platform:
-      architecture: amd64
-      os: windows
-      version: 2004
-  -
     image: rancher/windows_exporter-package:{{build.tag}}-windows-20H2
     platform:
       architecture: amd64
       os: windows
       version: 20H2
+  -
+    image: rancher/windows_exporter-package:{{build.tag}}-windows-ltsc2022
+    platform:
+      architecture: amd64
+      os: windows
+      version: ltsc2022


### PR DESCRIPTION
Adding Windows Server 2022 and removing 2004 since it goes out of support next month.

* rancher/rancher#36446
* https://github.com/rancher/windows/issues/112
* https://github.com/rancher/windows/issues/104

Signed-off-by: Jamie Phillips <jamie.phillips@suse.com>