### PR TITLE
Fix pipelines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,6 +3,11 @@ kind: pipeline
 type: docker
 name: windows-1809
 
+# Currently have to define "depth" as otherwise clone fails at
+# https://github.com/drone/drone-git/blob/39d233b3d9eccc68e66508a06a725a2567f33143/windows/clone-tag.ps1#L12
+clone:
+  depth: 20
+
 platform:
   os: windows
   arch: amd64
@@ -95,13 +100,12 @@ platform:
   arch: amd64
   version: 2022
 
-# remove this and use upstream images when https://github.com/drone/drone-git/pull/25 is merged
+# Currently have to define "depth" as otherwise clone fails at
+# https://github.com/drone/drone-git/blob/39d233b3d9eccc68e66508a06a725a2567f33143/windows/clone-tag.ps1#L12
 clone:
-  disable: true
+  depth: 20
 
 steps:
-  - name: clone
-    image: rancher/drone-images:git-amd64-ltsc2022
   - name: docker-build
     image: rancher/drone-images:docker-amd64-ltsc2022
     settings:


### PR DESCRIPTION
Relates to: https://github.com/rancher/windows/issues/222

Seems like this repo is hitting similar errors as wins, this PR mimics the changes in https://github.com/rancher/wins/pull/153 to fix the 1809 pipeline. The errors in [#12](https://drone-publish.rancher.io/rancher/windows_exporter-package/12) are exactly the same error seen in the `rancher/wins` repo. While PR runs work properly, tagging fails for the 1809 pipeline. 